### PR TITLE
Use pull requests as the release approval gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ jobs:
   publish:
     if: github.repository_owner == 'liamhawtin'
     runs-on: ubuntu-latest
-    environment: npm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6


### PR DESCRIPTION
This removes the redundant npm environment approval.\n\nAfter this PR passes CI and you merge it, the workflow is: review a PR, merge it into protected , then manually dispatch the release workflow when a version is ready. There is no second approval prompt.