### PR TITLE
Deploy Pages from the published npm package

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,13 @@
 name: Deploy demo site
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      package_version:
+        description: Published vieta-math version to demonstrate
+        required: true
+        default: "1.0.0"
+        type: string
 
 permissions:
   contents: read
@@ -21,14 +25,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20.19
-          cache: npm
-      - run: npm ci
-      - run: npm run build
-      - run: npm run build --workspace=@vietamath/demo-site
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm install --prefix examples/site --no-save vieta-math@${{ inputs.package_version }}
+      - run: npm run build --prefix examples/site
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,13 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: read
   id-token: write
 
 jobs:
   publish:
-    if: github.repository_owner == 'liamhawtin'
+    if: github.repository_owner == 'liamhawtin' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -25,3 +26,6 @@ jobs:
       - run: npm run build:examples
       - run: npm run test:browser
       - run: npm publish --provenance --access public
+      - run: gh workflow run pages.yml --ref main -f package_version="$(node -p "require('./package.json').version")"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Try the [live VietaMath demos](https://liamhawtin.github.io/vieta-math/): a
 standalone input, a theme override example, and a ProseMirror editor are all
 available in the browser.
 
+The published package is [vieta-math on npm](https://www.npmjs.com/package/vieta-math).
+
 ## Install
 
 VietaMath renders through React. React and ReactDOM are peer dependencies, so

--- a/examples/site/package.json
+++ b/examples/site/package.json
@@ -8,7 +8,7 @@
     "dev": "vite"
   },
   "dependencies": {
-    "vieta-math": "file:../..",
+    "vieta-math": "1.0.0",
     "prosemirror-history": "^1.5.0",
     "prosemirror-model": "^1.25.0",
     "prosemirror-schema-basic": "^1.2.4",

--- a/examples/site/src/main.jsx
+++ b/examples/site/src/main.jsx
@@ -41,7 +41,7 @@ function Shell({ children }) {
   const page = document.body.dataset.page;
   return <div className="site-shell">
     <header className="site-header"><a className="wordmark" href="./index.html">VietaMath</a><nav>{Object.entries(pages).slice(1).map(([key, [label, href]]) => <a className={key === page ? "active" : ""} href={`./${href}`} key={key}>{label}</a>)}</nav></header>
-    <main>{children}</main><footer>Browser math editing for advanced work. <a href="https://github.com/liamhawtin/vieta-math">Source</a></footer>
+    <main>{children}</main><footer>Browser math editing for advanced work. <a href="https://github.com/liamhawtin/vieta-math">Source</a> · <a href="https://www.npmjs.com/package/vieta-math">npm</a></footer>
   </div>;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,7 +155,7 @@
         "prosemirror-view": "^1.39.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "vieta-math": "file:../.."
+        "vieta-math": "1.0.0"
       },
       "devDependencies": {
         "vite": "^8.2.1"


### PR DESCRIPTION
Pages currently builds VietaMath through the workspace source link. This changes deployment to install an explicit published version from npm, and has the trusted release workflow trigger Pages after publishing that exact version.\n\nVerified separately with a fresh external React 19/Vite consumer that installed  from npm and built successfully.