### PR TITLE
Clarify security reporting contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,12 +3,11 @@
 Please do not open a public issue for a suspected security problem.
 
 Use GitHub's private vulnerability reporting feature for this repository. If it
-is unavailable, contact the maintainer through the email address on the npm
-package profile and do not include credentials or sensitive user data in the
-first message.
+is unavailable, email the maintainer at liamhawtin@gmail.com. Do not include
+credentials or sensitive user data in the first message.
 
 Include the affected version, a short description, and steps to reproduce the
-problem. You should receive an acknowledgement within seven days.
+problem.
 
 VietaMath is a client-side editor. Please report only issues in this repository
 through this repository's security-reporting channel.


### PR DESCRIPTION
Make the private-report fallback usable by naming the maintainer email directly, and remove an acknowledgement-time promise that is not backed by a support process.