### PR TITLE
Split demo editor code by route

### DIFF
--- a/examples/site/src/main.jsx
+++ b/examples/site/src/main.jsx
@@ -1,20 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { history } from "prosemirror-history";
-import { Schema } from "prosemirror-model";
-import { schema as basicSchema } from "prosemirror-schema-basic";
-import { EditorState } from "prosemirror-state";
-import { EditorView } from "prosemirror-view";
-import { UIRegistry, VietaMath } from "vieta-math";
-import {
-  createVietaMathNodeView,
-  exitActiveVietaMath,
-  insertVietaMath,
-  vietaMathInputRulesPlugin,
-  vietaMathNodes,
-  vietaMathPlugin,
-} from "vieta-math/prosemirror";
-import "prosemirror-view/style/prosemirror.css";
 import "./styles.css";
 
 const pages = {
@@ -49,7 +34,26 @@ function Standalone({ themed = false }) {
   const mount = useRef(null); const symbolPad = useRef(null); const smartMenu = useRef(null); const editor = useRef(null);
   const [latex, setLatex] = useState(""); const [dark, setDark] = useState(false);
   const systemTheme = useSystemTheme();
-  useEffect(() => { UIRegistry.mountSymbolPad(symbolPad.current); UIRegistry.mountSmartMenu(smartMenu.current); editor.current = new VietaMath(mount.current, { initialContent: String.raw`\int_0^1 x^2\,dx`, focusOnInit: true, symbolPadContainer: symbolPad.current, smartMenuContainer: smartMenu.current, onChange: setLatex }); setLatex(editor.current.getLatex()); return () => { editor.current?.destroy(); UIRegistry.unmountSymbolPad(); UIRegistry.unmountSmartMenu(); }; }, []);
+  useEffect(() => {
+    let active = true;
+    let UIRegistry;
+
+    void import("vieta-math").then(({ UIRegistry: registry, VietaMath }) => {
+      if (!active) return;
+      UIRegistry = registry;
+      UIRegistry.mountSymbolPad(symbolPad.current);
+      UIRegistry.mountSmartMenu(smartMenu.current);
+      editor.current = new VietaMath(mount.current, { initialContent: String.raw`\int_0^1 x^2\,dx`, focusOnInit: true, symbolPadContainer: symbolPad.current, smartMenuContainer: smartMenu.current, onChange: setLatex });
+      setLatex(editor.current.getLatex());
+    });
+
+    return () => {
+      active = false;
+      editor.current?.destroy();
+      UIRegistry?.unmountSymbolPad();
+      UIRegistry?.unmountSmartMenu();
+    };
+  }, []);
   const content = <><div className="demo-toolbar"><button onClick={() => editor.current?.setLatex(String.raw`\sum_{k=1}^{n} k^2`)}>Load a sum</button><button onClick={() => setLatex(editor.current?.getSanitizedLatex() ?? "")}>Show export</button><button onClick={() => editor.current?.blur()}>Blur editor</button></div><div ref={smartMenu} /><div ref={mount} className="math-mount" /><p className="help">Press Tab while editing to open the symbol menu.</p><p className="status">Current LaTeX</p><pre>{latex || "Start editing the expression above."}</pre><div ref={symbolPad} className="symbol-mount" /></>;
   if (!themed) return <section className={`demo-card site-${systemTheme}`} data-theme={systemTheme}>{content}</section>;
   return <section className={`theme-demo ${dark ? "theme-dark" : "theme-light"}`} data-theme={dark ? "dark" : "light"}><div className="demo-toolbar"><span>Override preview</span><button onClick={() => setDark(v => !v)}>Use {dark ? "light" : "dark"} values</button></div>{content}<aside><strong>Two layers</strong><code>.vieta-root</code><code>.vieta-root .interactive-mathml</code><p>The CSS values here use the same muted-teal visual language as the demo site.</p></aside></section>;
@@ -58,8 +62,41 @@ function Standalone({ themed = false }) {
 function ProseMirrorDemo() {
   const host = useRef(null); const symbolPad = useRef(null); const smartMenu = useRef(null); const viewRef = useRef(null); const [text, setText] = useState("");
   const systemTheme = useSystemTheme();
-  useEffect(() => { const schema = new Schema({ nodes: basicSchema.spec.nodes.append(vietaMathNodes), marks: basicSchema.spec.marks }); const state = EditorState.create({ schema, plugins: [vietaMathInputRulesPlugin(schema), vietaMathPlugin(schema), history()] }); const view = new EditorView(host.current, { state, nodeViews: { vieta_math_inline: createVietaMathNodeView(VietaMath, { symbolPadContainer: symbolPad.current, smartMenuContainer: smartMenu.current }) }, dispatchTransaction(tr) { view.updateState(view.state.apply(tr)); setText(view.state.doc.textContent); } }); viewRef.current = view; UIRegistry.mountSymbolPad(symbolPad.current); UIRegistry.mountSmartMenu(smartMenu.current); setText(view.state.doc.textContent); return () => { view.destroy(); UIRegistry.unmountSymbolPad(); UIRegistry.unmountSmartMenu(); }; }, []);
-  return <section className={`demo-card site-${systemTheme}`} data-theme={systemTheme}><div className="demo-toolbar"><button onClick={() => { const v = viewRef.current; if (v) insertVietaMath(v.state.schema, String.raw`\sqrt{x^2+y^2}`)(v.state, v.dispatch); }}>Insert math</button><button onClick={() => viewRef.current && exitActiveVietaMath(viewRef.current)}>Exit active math</button></div><p className="help">Type <code>$x^2$</code> to make an inline math node. Arrow keys enter and leave an active node.</p><div ref={smartMenu} /><div ref={host} className="prosemirror-mount" /><p className="status">Document text</p><pre>{text || "The document is empty."}</pre><div ref={symbolPad} className="symbol-mount" /></section>;
+  const commands = useRef(null);
+  useEffect(() => {
+    let active = true;
+    let UIRegistry;
+
+    void Promise.all([
+      import("vieta-math"),
+      import("vieta-math/prosemirror"),
+      import("prosemirror-history"),
+      import("prosemirror-model"),
+      import("prosemirror-schema-basic"),
+      import("prosemirror-state"),
+      import("prosemirror-view"),
+      import("prosemirror-view/style/prosemirror.css"),
+    ]).then(([{ UIRegistry: registry, VietaMath }, prosemirror, { history }, { Schema }, { schema: basicSchema }, { EditorState }, { EditorView }]) => {
+      if (!active) return;
+      UIRegistry = registry;
+      const schema = new Schema({ nodes: basicSchema.spec.nodes.append(prosemirror.vietaMathNodes), marks: basicSchema.spec.marks });
+      const state = EditorState.create({ schema, plugins: [prosemirror.vietaMathInputRulesPlugin(schema), prosemirror.vietaMathPlugin(schema), history()] });
+      const view = new EditorView(host.current, { state, nodeViews: { vieta_math_inline: prosemirror.createVietaMathNodeView(VietaMath, { symbolPadContainer: symbolPad.current, smartMenuContainer: smartMenu.current }) }, dispatchTransaction(tr) { view.updateState(view.state.apply(tr)); setText(view.state.doc.textContent); } });
+      commands.current = prosemirror;
+      viewRef.current = view;
+      UIRegistry.mountSymbolPad(symbolPad.current);
+      UIRegistry.mountSmartMenu(smartMenu.current);
+      setText(view.state.doc.textContent);
+    });
+
+    return () => {
+      active = false;
+      viewRef.current?.destroy();
+      UIRegistry?.unmountSymbolPad();
+      UIRegistry?.unmountSmartMenu();
+    };
+  }, []);
+  return <section className={`demo-card site-${systemTheme}`} data-theme={systemTheme}><div className="demo-toolbar"><button onClick={() => { const v = viewRef.current; if (v) commands.current?.insertVietaMath(v.state.schema, String.raw`\sqrt{x^2+y^2}`)(v.state, v.dispatch); }}>Insert math</button><button onClick={() => viewRef.current && commands.current?.exitActiveVietaMath(viewRef.current)}>Exit active math</button></div><p className="help">Type <code>$x^2$</code> to make an inline math node. Arrow keys enter and leave an active node.</p><div ref={smartMenu} /><div ref={host} className="prosemirror-mount" /><p className="status">Document text</p><pre>{text || "The document is empty."}</pre><div ref={symbolPad} className="symbol-mount" /></section>;
 }
 
 function Home() { return <><section className="hero"><img className="brand-lockup" src="./vieta-space-logo.svg" alt="VietaSpace" /><p className="eyebrow">Open-source browser math editing</p><h1>Work directly with advanced mathematical structure.</h1><p>These demos show VietaMath as a standalone input, a themeable component, and inline ProseMirror content.</p><p><strong>Desktop browser and physical keyboard required.</strong> Phones are not supported in this release.</p><div className="actions"><a href="./standalone.html">Try the editor</a><a href="./prosemirror.html">See ProseMirror</a></div></section><section className="overview"><a href="./standalone.html"><h2>Standalone</h2><p>Mount an editor, optional shared UI, and export clean LaTeX.</p></a><a href="./theme.html"><h2>Theme variables</h2><p>Inspect the two CSS-variable layers in a live host theme.</p></a><a href="./prosemirror.html"><h2>ProseMirror</h2><p>Insert, edit, navigate, and serialize inline math nodes.</p></a></section><section className="product-preview"><div><p className="eyebrow">VietaSpace in use</p><h2>Build and explain mathematics in the browser.</h2><p>This short walkthrough shows a VietaSpace math workflow built around the same editing model.</p></div><video controls muted loop playsInline preload="metadata" poster="./favicon-256x256.png"><source src="./vieta-math-demo.mp4" type="video/mp4" />Your browser does not support this video.</video></section></> }

--- a/examples/site/src/main.jsx
+++ b/examples/site/src/main.jsx
@@ -32,7 +32,7 @@ function Shell({ children }) {
 
 function Standalone({ themed = false }) {
   const mount = useRef(null); const symbolPad = useRef(null); const smartMenu = useRef(null); const editor = useRef(null);
-  const [latex, setLatex] = useState(""); const [dark, setDark] = useState(false);
+  const [latex, setLatex] = useState(""); const [dark, setDark] = useState(false); const [ready, setReady] = useState(false);
   const systemTheme = useSystemTheme();
   useEffect(() => {
     let active = true;
@@ -45,6 +45,7 @@ function Standalone({ themed = false }) {
       UIRegistry.mountSmartMenu(smartMenu.current);
       editor.current = new VietaMath(mount.current, { initialContent: String.raw`\int_0^1 x^2\,dx`, focusOnInit: true, symbolPadContainer: symbolPad.current, smartMenuContainer: smartMenu.current, onChange: setLatex });
       setLatex(editor.current.getLatex());
+      setReady(true);
     });
 
     return () => {
@@ -54,13 +55,13 @@ function Standalone({ themed = false }) {
       UIRegistry?.unmountSmartMenu();
     };
   }, []);
-  const content = <><div className="demo-toolbar"><button onClick={() => editor.current?.setLatex(String.raw`\sum_{k=1}^{n} k^2`)}>Load a sum</button><button onClick={() => setLatex(editor.current?.getSanitizedLatex() ?? "")}>Show export</button><button onClick={() => editor.current?.blur()}>Blur editor</button></div><div ref={smartMenu} /><div ref={mount} className="math-mount" /><p className="help">Press Tab while editing to open the symbol menu.</p><p className="status">Current LaTeX</p><pre>{latex || "Start editing the expression above."}</pre><div ref={symbolPad} className="symbol-mount" /></>;
+  const content = <><div className="demo-toolbar"><button disabled={!ready} onClick={() => editor.current?.setLatex(String.raw`\sum_{k=1}^{n} k^2`)}>Load a sum</button><button disabled={!ready} onClick={() => setLatex(editor.current?.getSanitizedLatex() ?? "")}>Show export</button><button disabled={!ready} onClick={() => editor.current?.blur()}>Blur editor</button></div><div ref={smartMenu} /><div ref={mount} className="math-mount" /><p className="help">Press Tab while editing to open the symbol menu.</p><p className="status">Current LaTeX</p><pre>{latex || (ready ? "Start editing the expression above." : "Loading editor…")}</pre><div ref={symbolPad} className="symbol-mount" /></>;
   if (!themed) return <section className={`demo-card site-${systemTheme}`} data-theme={systemTheme}>{content}</section>;
   return <section className={`theme-demo ${dark ? "theme-dark" : "theme-light"}`} data-theme={dark ? "dark" : "light"}><div className="demo-toolbar"><span>Override preview</span><button onClick={() => setDark(v => !v)}>Use {dark ? "light" : "dark"} values</button></div>{content}<aside><strong>Two layers</strong><code>.vieta-root</code><code>.vieta-root .interactive-mathml</code><p>The CSS values here use the same muted-teal visual language as the demo site.</p></aside></section>;
 }
 
 function ProseMirrorDemo() {
-  const host = useRef(null); const symbolPad = useRef(null); const smartMenu = useRef(null); const viewRef = useRef(null); const [text, setText] = useState("");
+  const host = useRef(null); const symbolPad = useRef(null); const smartMenu = useRef(null); const viewRef = useRef(null); const [text, setText] = useState(""); const [ready, setReady] = useState(false);
   const systemTheme = useSystemTheme();
   const commands = useRef(null);
   useEffect(() => {
@@ -87,6 +88,7 @@ function ProseMirrorDemo() {
       UIRegistry.mountSymbolPad(symbolPad.current);
       UIRegistry.mountSmartMenu(smartMenu.current);
       setText(view.state.doc.textContent);
+      setReady(true);
     });
 
     return () => {
@@ -96,7 +98,7 @@ function ProseMirrorDemo() {
       UIRegistry?.unmountSmartMenu();
     };
   }, []);
-  return <section className={`demo-card site-${systemTheme}`} data-theme={systemTheme}><div className="demo-toolbar"><button onClick={() => { const v = viewRef.current; if (v) commands.current?.insertVietaMath(v.state.schema, String.raw`\sqrt{x^2+y^2}`)(v.state, v.dispatch); }}>Insert math</button><button onClick={() => viewRef.current && commands.current?.exitActiveVietaMath(viewRef.current)}>Exit active math</button></div><p className="help">Type <code>$x^2$</code> to make an inline math node. Arrow keys enter and leave an active node.</p><div ref={smartMenu} /><div ref={host} className="prosemirror-mount" /><p className="status">Document text</p><pre>{text || "The document is empty."}</pre><div ref={symbolPad} className="symbol-mount" /></section>;
+  return <section className={`demo-card site-${systemTheme}`} data-theme={systemTheme}><div className="demo-toolbar"><button disabled={!ready} onClick={() => { const v = viewRef.current; if (v) commands.current?.insertVietaMath(v.state.schema, String.raw`\sqrt{x^2+y^2}`)(v.state, v.dispatch); }}>Insert math</button><button disabled={!ready} onClick={() => viewRef.current && commands.current?.exitActiveVietaMath(viewRef.current)}>Exit active math</button></div><p className="help">Type <code>$x^2$</code> to make an inline math node. Arrow keys enter and leave an active node.</p><div ref={smartMenu} /><div ref={host} className="prosemirror-mount" /><p className="status">Document text</p><pre>{text || (ready ? "The document is empty." : "Loading editor…")}</pre><div ref={symbolPad} className="symbol-mount" /></section>;
 }
 
 function Home() { return <><section className="hero"><img className="brand-lockup" src="./vieta-space-logo.svg" alt="VietaSpace" /><p className="eyebrow">Open-source browser math editing</p><h1>Work directly with advanced mathematical structure.</h1><p>These demos show VietaMath as a standalone input, a themeable component, and inline ProseMirror content.</p><p><strong>Desktop browser and physical keyboard required.</strong> Phones are not supported in this release.</p><div className="actions"><a href="./standalone.html">Try the editor</a><a href="./prosemirror.html">See ProseMirror</a></div></section><section className="overview"><a href="./standalone.html"><h2>Standalone</h2><p>Mount an editor, optional shared UI, and export clean LaTeX.</p></a><a href="./theme.html"><h2>Theme variables</h2><p>Inspect the two CSS-variable layers in a live host theme.</p></a><a href="./prosemirror.html"><h2>ProseMirror</h2><p>Insert, edit, navigate, and serialize inline math nodes.</p></a></section><section className="product-preview"><div><p className="eyebrow">VietaSpace in use</p><h2>Build and explain mathematics in the browser.</h2><p>This short walkthrough shows a VietaSpace math workflow built around the same editing model.</p></div><video controls muted loop playsInline preload="metadata" poster="./favicon-256x256.png"><source src="./vieta-math-demo.mp4" type="video/mp4" />Your browser does not support this video.</video></section></> }

--- a/tests/browser/demo-site.spec.js
+++ b/tests/browser/demo-site.spec.js
@@ -100,6 +100,7 @@ test("ProseMirror Smart Menu is anchored to the caret in the viewport", async ({
   await page.goto("/prosemirror.html");
   await page.getByRole("button", { name: "Insert math" }).click();
   const editor = page.locator(".interactive-mathml");
+  await expect(editor).toBeVisible();
   await editor.click({ position: { x: 12, y: 12 } });
   const caret = page.locator(".math-cursor");
   await expect(caret).toBeVisible();


### PR DESCRIPTION
The landing page no longer imports the VietaMath or ProseMirror runtime. Each interactive route dynamically loads the code it needs, while preserving the existing demo behavior and cleanup paths.

Validation: demo-site production build completed; browser suite passed 8 tests.