### PR TITLE
Fix automated Pages dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,6 @@ jobs:
       (needs.preflight.outputs.should_publish != 'true' || needs.publish.result == 'success')
     runs-on: ubuntu-latest
     steps:
-      - run: gh workflow run pages.yml --ref main -f package_version="${{ needs.preflight.outputs.package_version }}"
+      - run: gh workflow run pages.yml --repo "$GITHUB_REPOSITORY" --ref main -f package_version="${{ needs.preflight.outputs.package_version }}"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The protected-main release workflow needs an explicit repository target when it dispatches Pages from a runner without a checkout. This keeps the verified release gate intact and repairs the final Pages handoff.