### PR TITLE
Verify source examples before publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ React pair explicitly:
 npm install vieta-math react react-dom
 ```
 
-VietaMath supports React 18 and 19 internally. It needs a browser DOM, so
+VietaMath currently supports React 18 internally. It needs a browser DOM, so
 create editor instances only in client-side code.
 
 ### Device support

--- a/examples/site/package.json
+++ b/examples/site/package.json
@@ -15,7 +15,7 @@
     "prosemirror-view": "^1.39.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "vieta-math": "1.0.6"
+    "vieta-math": "file:../.."
   },
   "devDependencies": {
     "vite": "^8.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vieta-math",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vieta-math",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "workspaces": [
         "latex-math-engine",
@@ -45,8 +45,8 @@
         "webpack-cli": "^5.1.4"
       },
       "peerDependencies": {
-        "react": ">=18 <20",
-        "react-dom": ">=18 <20"
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19"
       }
     },
     "examples/prosemirror": {
@@ -155,7 +155,7 @@
         "prosemirror-view": "^1.39.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "vieta-math": "1.0.6"
+        "vieta-math": "file:../.."
       },
       "devDependencies": {
         "vite": "^8.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vieta-math",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": false,
   "workspaces": [
     "latex-math-engine",
@@ -76,8 +76,8 @@
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
-    "react": ">=18 <20",
-    "react-dom": ">=18 <20"
+    "react": ">=18 <19",
+    "react-dom": ">=18 <19"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",


### PR DESCRIPTION
Narrows the declared React peer range to the tested React 18 major version and keeps the Pages workspace linked to the local package during pull-request CI. Pages deployment still explicitly installs the exact published npm version.