### PR TITLE
Verify ProseMirror document export

### DIFF
--- a/examples/prosemirror/vite.config.js
+++ b/examples/prosemirror/vite.config.js
@@ -1,0 +1,12 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+
+// Build the source example against the package artifact made by the root build.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "vieta-math/prosemirror": resolve(import.meta.dirname, "../../dist/vieta-math-prosemirror.mjs"),
+      "vieta-math": resolve(import.meta.dirname, "../../dist/index.mjs"),
+    },
+  },
+});

--- a/examples/site/src/main.jsx
+++ b/examples/site/src/main.jsx
@@ -92,8 +92,14 @@ function Standalone({ themed = false }) {
   return <section className={`theme-demo ${dark ? "theme-dark" : "theme-light"}`} data-theme={dark ? "dark" : "light"}><div className="demo-toolbar"><button onClick={() => setDark(v => !v)}>Use {dark ? "light" : "dark"} values</button></div>{content}<ThemeGuide dark={dark} /></section>;
 }
 
+function serializeDocument(state, serializer) {
+  const wrapper = document.createElement("div");
+  wrapper.append(serializer.serializeFragment(state.doc.content));
+  return wrapper.innerHTML;
+}
+
 function ProseMirrorDemo() {
-  const host = useRef(null); const symbolPad = useRef(null); const smartMenu = useRef(null); const viewRef = useRef(null); const [text, setText] = useState(""); const [ready, setReady] = useState(false); const [apiReady, setApiReady] = useState(false);
+  const host = useRef(null); const symbolPad = useRef(null); const smartMenu = useRef(null); const viewRef = useRef(null); const [text, setText] = useState(""); const [exportedHtml, setExportedHtml] = useState(""); const [ready, setReady] = useState(false); const [apiReady, setApiReady] = useState(false);
   const systemTheme = useSystemTheme();
   const commands = useRef(null);
   useEffect(() => {
@@ -109,18 +115,20 @@ function ProseMirrorDemo() {
       import("prosemirror-state"),
       import("prosemirror-view"),
       import("prosemirror-view/style/prosemirror.css"),
-    ]).then(([{ UIRegistry: registry, VietaMath }, prosemirror, { history }, { Schema }, { schema: basicSchema }, { EditorState }, { EditorView }]) => {
+    ]).then(([{ UIRegistry: registry, VietaMath }, prosemirror, { history }, { Schema, DOMSerializer }, { schema: basicSchema }, { EditorState }, { EditorView }]) => {
       if (!active) return;
       UIRegistry = registry;
       const schema = new Schema({ nodes: basicSchema.spec.nodes.append(prosemirror.vietaMathNodes), marks: basicSchema.spec.marks });
       const state = EditorState.create({ schema, plugins: [prosemirror.vietaMathInputRulesPlugin(schema), prosemirror.vietaMathPlugin(schema), history()] });
-      const view = new EditorView(host.current, { state, nodeViews: { vieta_math_inline: prosemirror.createVietaMathNodeView(VietaMath, { symbolPadContainer: symbolPad.current, smartMenuContainer: smartMenu.current }) }, dispatchTransaction(tr) { view.updateState(view.state.apply(tr)); setText(view.state.doc.textContent); } });
+      const serializer = DOMSerializer.fromSchema(schema);
+      const view = new EditorView(host.current, { state, nodeViews: { vieta_math_inline: prosemirror.createVietaMathNodeView(VietaMath, { symbolPadContainer: symbolPad.current, smartMenuContainer: smartMenu.current }) }, dispatchTransaction(tr) { view.updateState(view.state.apply(tr)); setText(view.state.doc.textContent); setExportedHtml(serializeDocument(view.state, serializer)); } });
       commands.current = prosemirror;
       setApiReady(Boolean(prosemirror.vietaMathKey && prosemirror.vietaMathInputRulesKey));
       viewRef.current = view;
       UIRegistry.mountSymbolPad(symbolPad.current);
       UIRegistry.mountSmartMenu(smartMenu.current);
       setText(view.state.doc.textContent);
+      setExportedHtml(serializeDocument(view.state, serializer));
       setReady(true);
     });
 
@@ -131,7 +139,7 @@ function ProseMirrorDemo() {
       UIRegistry?.unmountSmartMenu();
     };
   }, []);
-  return <section className={`demo-card site-${systemTheme}`} data-theme={systemTheme} data-prosemirror-api={apiReady ? "ready" : "missing"}><div className="demo-toolbar"><button disabled={!ready} onClick={() => { const v = viewRef.current; if (v) commands.current?.insertVietaMath(v.state.schema, String.raw`\sqrt{x^2+y^2}`)(v.state, v.dispatch); }}>Insert math</button><button disabled={!ready} onClick={() => viewRef.current && commands.current?.exitActiveVietaMath(viewRef.current)}>Exit active math</button></div><p className="help">Type <code>$x^2$</code> to make an inline math node. Arrow keys enter and leave an active node.</p><div ref={smartMenu} /><div ref={host} className="prosemirror-mount" /><details className="demo-details"><summary>Inspect document text</summary><pre>{text || (ready ? "The document is empty." : "Loading editor…")}</pre></details><details className="optional-tools"><summary>Optional shared Symbol Pad</summary><p>Mount one pad for the surrounding editor view, then pass its container to VietaMath’s node view.</p><div ref={symbolPad} className="symbol-mount" /></details></section>;
+  return <section className={`demo-card site-${systemTheme}`} data-theme={systemTheme} data-prosemirror-api={apiReady ? "ready" : "missing"}><div className="demo-toolbar"><button disabled={!ready} onClick={() => { const v = viewRef.current; if (v) commands.current?.insertVietaMath(v.state.schema, String.raw`\sqrt{x^2+y^2}`)(v.state, v.dispatch); }}>Insert math</button><button disabled={!ready} onClick={() => viewRef.current && commands.current?.exitActiveVietaMath(viewRef.current)}>Exit active math</button></div><p className="help">Type <code>$x^2$</code> to make an inline math node. Arrow keys enter and leave an active node.</p><div ref={smartMenu} /><div ref={host} className="prosemirror-mount" /><details className="demo-details"><summary>Inspect document text</summary><pre>{text || (ready ? "The document is empty." : "Loading editor…")}</pre></details><details className="demo-details"><summary>Inspect exported document HTML</summary><pre className="document-export">{exportedHtml || (ready ? "The document is empty." : "Loading editor…")}</pre></details><details className="optional-tools"><summary>Optional shared Symbol Pad</summary><p>Mount one pad for the surrounding editor view, then pass its container to VietaMath’s node view.</p><div ref={symbolPad} className="symbol-mount" /></details></section>;
 }
 
 function Home() { return <><section className="hero"><div className="product-provenance"><img src="./vieta-space-logo.svg" alt="VietaSpace" /><span>VietaMath by VietaSpace</span></div><p className="eyebrow">Open-source browser math editor</p><h1>Write mathematics as mathematics.</h1><p>VietaMath gives structured expressions a real cursor, keyboard navigation, and clean LaTeX export—inside a standalone field or a ProseMirror document.</p><div className="actions"><a href="#try-editor">Try the editor</a><a href="https://github.com/liamhawtin/vieta-math#install">View installation</a></div></section><HomePreview /><section className="integration-paths" aria-labelledby="paths-title"><div><p className="eyebrow">Choose an integration</p><h2 id="paths-title">Use the editor where your work lives.</h2></div><div className="path-grid"><a href="./standalone.html"><span>01</span><h3>Standalone</h3><p>A focused math field, with optional shared tools and LaTeX export.</p><strong>Explore standalone <span aria-hidden="true">→</span></strong></a><a href="./prosemirror.html"><span>02</span><h3>ProseMirror</h3><p>Inline math nodes that are part of an editable document.</p><strong>Explore ProseMirror <span aria-hidden="true">→</span></strong></a><a href="./theme.html"><span>03</span><h3>Theming</h3><p>Explicit host colors and CSS variables that match the application around it.</p><strong>Explore theming <span aria-hidden="true">→</span></strong></a></div></section><section className="product-preview"><div><p className="eyebrow">VietaSpace workflow</p><h2>See the same editing model in use.</h2><p>A short VietaSpace walkthrough of building and explaining an integral in the browser.</p></div><video controls muted loop playsInline preload="metadata" poster="./vieta-math-demo-poster.png"><source src="./vieta-math-demo.mp4" type="video/mp4" />Your browser does not support this video.</video></section><p className="device-boundary">Built for desktop-class browsers and a physical keyboard. Phones are not supported.</p></> }

--- a/examples/site/vite.config.js
+++ b/examples/site/vite.config.js
@@ -1,8 +1,24 @@
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { defineConfig } from "vite";
 
+const installedPackage = resolve(import.meta.dirname, "node_modules/vieta-math/dist/index.mjs");
+const installedProseMirrorPackage = resolve(import.meta.dirname, "node_modules/vieta-math/dist/vieta-math-prosemirror.mjs");
+const sourcePackage = resolve(import.meta.dirname, "../../dist/index.mjs");
+const sourceProseMirrorPackage = resolve(import.meta.dirname, "../../dist/vieta-math-prosemirror.mjs");
+
 export default defineConfig({
   base: "./",
+  resolve: {
+    alias: {
+      // CI uses the local root artifact. Pages installs an exact npm version
+      // into this workspace first, so that deployed build uses that package.
+      "vieta-math/prosemirror": existsSync(installedProseMirrorPackage)
+        ? installedProseMirrorPackage
+        : sourceProseMirrorPackage,
+      "vieta-math": existsSync(installedPackage) ? installedPackage : sourcePackage,
+    },
+  },
   build: {
     rollupOptions: {
       input: {

--- a/examples/standalone/vite.config.js
+++ b/examples/standalone/vite.config.js
@@ -1,0 +1,12 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vite";
+
+// Vite does not reliably resolve the workspace package back through its own
+// symlink during a clean install. The root build runs before example builds.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "vieta-math": resolve(import.meta.dirname, "../../dist/index.mjs"),
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vieta-math",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vieta-math",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "workspaces": [
         "latex-math-engine",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vieta-math",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": false,
   "workspaces": [
     "latex-math-engine",

--- a/tests/browser/demo-site.spec.js
+++ b/tests/browser/demo-site.spec.js
@@ -117,6 +117,16 @@ test("ProseMirror demo creates an inline VietaMath node", async ({ page }) => {
   expect(errors).toEqual([]);
 });
 
+test("ProseMirror demo serializes an inserted node as exported LaTeX", async ({ page }) => {
+  await page.goto("/prosemirror.html");
+  await page.getByRole("button", { name: "Insert math" }).click();
+  const exported = page.locator(".document-export");
+  await expect(exported).toContainText('class="pm-vieta-math"');
+  await expect(exported).toContainText('data-vieta-math="1"');
+  await expect(exported).toContainText("$\\sqrt{x^2+y^2}$");
+  await expect(exported).not.toContainText("mkern");
+});
+
 test("ProseMirror Smart Menu stays in the viewport", async ({ page }) => {
   await page.goto("/prosemirror.html");
   await page.getByRole("button", { name: "Insert math" }).click();


### PR DESCRIPTION
Adds an optional exported-document inspector to the ProseMirror demo and browser coverage for the schema DOM export. It also makes source example builds deterministic after npm ci while keeping Pages pinned to the exact installed npm package.