### PR TITLE
Use ProseMirror math instance identity for events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vieta-math",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vieta-math",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "workspaces": [
         "latex-math-engine",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vieta-math",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": false,
   "workspaces": [
     "latex-math-engine",

--- a/src/integrations/ProseMirrorNodeView.js
+++ b/src/integrations/ProseMirrorNodeView.js
@@ -83,9 +83,9 @@ class VietaMathInlineView {
     return true;
   }
 
-  stopEvent(event) {
-    // doesn't do anything, wrong id check, but it doesn't matter
-    return registry.getActiveId() === this.id;
+  stopEvent(_event) {
+    // ProseMirror must leave events inside the active embedded editor alone.
+    return registry.getActiveId() === this.instanceId;
   }
 
   ignoreMutation(_mutation) {

--- a/src/integrations/ProseMirrorPlugin.js
+++ b/src/integrations/ProseMirrorPlugin.js
@@ -247,7 +247,7 @@ export const vietaMathPlugin = (schema) => {
         } else {
 
           // Ignore selections outside this ProseMirror view
-          const anchor = sel.anchorNode.parentElement;;
+          const anchor = sel.anchorNode.parentElement;
           if (!view.dom.contains(anchor)) return;
 
           // Find enclosing VietaMath wrapper, if any

--- a/src/integrations/vietaMathCommands.js
+++ b/src/integrations/vietaMathCommands.js
@@ -116,7 +116,7 @@ export function ensureMathLineVisible(view) {
   const mathWrapper = container.closest?.(".pm-vieta-math-wrapper");
   if (mathWrapper) {
     container = mathWrapper;
-    anchorRect = mathWrapper.getClientRects()[0] || null;;
+    anchorRect = mathWrapper.getClientRects()[0] || null;
   }
 
   if (!anchorRect) return;


### PR DESCRIPTION
Corrects the node-view event guard to compare the active registry instance ID, removes a misleading comment, and cleans up two accidental duplicate semicolons.