### PR TITLE
Add GitHub Sponsors link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: liamhawtin

--- a/README.md
+++ b/README.md
@@ -250,3 +250,8 @@ Current maintainer: Liam Hawtin.
 
 Interested in becoming a long-term maintainer or collaborator and helping
 shape the project? Email liamhawtin@gmail.com.
+
+## Support VietaMath
+
+If VietaMath is useful to you, you can support its maintenance through
+[GitHub Sponsors](https://github.com/sponsors/liamhawtin).


### PR DESCRIPTION
Adds the repository Sponsors button and a short README link to the newly active GitHub Sponsors profile.